### PR TITLE
Fixed word occurrence bug with God Titus 2:11

### DIFF
--- a/resources/en/bibles/ulb/v12.1/tit/1.json
+++ b/resources/en/bibles/ulb/v12.1/tit/1.json
@@ -1032,7 +1032,7 @@
             "tag": "w",
             "type": "word",
             "occurrence": 1,
-            "occurrences": 2
+            "occurrences": 1
           }
         ]
       },

--- a/resources/en/bibles/ulb/v12.1/tit/2.json
+++ b/resources/en/bibles/ulb/v12.1/tit/2.json
@@ -3032,25 +3032,6 @@
       {
         "tag": "zaln",
         "type": "milestone",
-        "lemma": "πᾶς",
-        "morph": "Gr,EQ,,,,DMP,",
-        "occurrence": 1,
-        "occurrences": 1,
-        "strong": "G39560",
-        "content": "πᾶσιν",
-        "children": [
-          {
-            "text": "of",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 2
-          }
-        ]
-      },
-      {
-        "tag": "zaln",
-        "type": "milestone",
         "lemma": "ὁ",
         "morph": "Gr,EA,,,,GMS,",
         "occurrence": 1,
@@ -3068,6 +3049,13 @@
             "strong": "G23160",
             "content": "Θεοῦ",
             "children": [
+              {
+                "text": "of",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 2
+              },
               {
                 "text": "God",
                 "tag": "w",
@@ -3141,37 +3129,6 @@
       {
         "tag": "zaln",
         "type": "milestone",
-        "lemma": "ὁ",
-        "morph": "Gr,EA,,,,GMS,",
-        "occurrence": 1,
-        "occurrences": 1,
-        "strong": "G35880",
-        "content": "τοῦ",
-        "children": [
-          {
-            "tag": "zaln",
-            "type": "milestone",
-            "lemma": "θεός",
-            "morph": "Gr,N,,,,,GMS,",
-            "occurrence": 1,
-            "occurrences": 1,
-            "strong": "G23160",
-            "content": "Θεοῦ",
-            "children": [
-              {
-                "text": "of",
-                "tag": "w",
-                "type": "word",
-                "occurrence": 2,
-                "occurrences": 2
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "tag": "zaln",
-        "type": "milestone",
         "lemma": "πᾶς",
         "morph": "Gr,EQ,,,,DMP,",
         "occurrence": 1,
@@ -3179,6 +3136,13 @@
         "strong": "G39560",
         "content": "πᾶσιν",
         "children": [
+          {
+            "text": "of",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 2,
+            "occurrences": 2
+          },
           {
             "text": "all",
             "tag": "w",

--- a/resources/en/bibles/ulb/v12.1/tit/3.json
+++ b/resources/en/bibles/ulb/v12.1/tit/3.json
@@ -695,7 +695,7 @@
                 "tag": "w",
                 "type": "word",
                 "occurrence": 1,
-                "occurrences": 4
+                "occurrences": 1
               },
               {
                 "text": "ourselves",
@@ -1737,7 +1737,7 @@
             "tag": "w",
             "type": "word",
             "occurrence": 1,
-            "occurrences": 2
+            "occurrences": 1
           }
         ]
       },
@@ -1756,7 +1756,7 @@
             "tag": "w",
             "type": "word",
             "occurrence": 1,
-            "occurrences": 2
+            "occurrences": 1
           }
         ]
       },


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fixed word occurrence bug with God Titus 2:11

#### Please include detailed Test instructions for your pull request:
- Delete your resources folder.
- Open **God Titus 2:11** in `translationWords  tool` and both the Greek and English ULB should highlight the word properly.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc_resources/34)
<!-- Reviewable:end -->
